### PR TITLE
fix: reduce stack sizes for audio and video

### DIFF
--- a/src/constants/av.rs
+++ b/src/constants/av.rs
@@ -1,10 +1,16 @@
 use std::time::Duration;
 
+// Break out module properly
+
 // pub const BULK_ENDPOINT_ADDRESS: u8 = 130;
 pub const VID_3DS: u16 = 0x16D0;
 pub const PID_3DS: u16 = 0x06A3;
 
-// Will this break if we drop below 10fps?
+// Errors
+pub const CANNOT_FIND_3DS = "unable to locate 3ds device";
+pub const CANNOT_CONFIGURE_3DS = "could not configure 3ds device";
+
+// Consider if will work below 10fps
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
 pub const VEND_OUT_REQ: u8 = 0x40;
 pub const VEND_OUT_VALUE: u16 = 0;
@@ -19,6 +25,8 @@ pub const AUDIO_BUFFER_SIZE: usize = 4376;
 pub const AUDIO_SAMPLE_HZ: u32 = 32728;
 pub const AUDIO_NUM_ZEROES_END_DELIMETER: usize = 256;
 pub const MAX_QUEUED_FRAMES: usize = 5;
+pub const VIDEO_THREAD_STACK_SIZE: usize = 1024 * 1024 * 10;
+pub const AUDIO_THREAD_STACK_SIZE: usize = 1024 * 1024 * 2;
 
 pub const FULL_BUFF_SIZE: usize = VIDEO_BUFFER_SIZE + AUDIO_BUFFER_SIZE;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 mod constants;
-use constants::av::MAX_QUEUED_FRAMES;
 use constants::av::{
-    AUDIO_BUFFER_SIZE, AUDIO_NUM_ZEROES_END_DELIMETER, AUDIO_SAMPLE_HZ, DEFAULT_TIMEOUT,
-    FULL_BUFF_SIZE, PID_3DS, TARGET_FPS, VEND_OUT_IDX, VEND_OUT_REQ, VEND_OUT_VALUE,
-    VIDEO_BUFFER_SIZE, VID_3DS, WINDOW_HEIGHT, WINDOW_WIDTH,
+    AUDIO_BUFFER_SIZE, AUDIO_NUM_ZEROES_END_DELIMETER, AUDIO_SAMPLE_HZ, AUDIO_THREAD_STACK_SIZE,
+    DEFAULT_TIMEOUT, FULL_BUFF_SIZE, PID_3DS, TARGET_FPS, VEND_OUT_IDX, VEND_OUT_REQ,
+    VEND_OUT_VALUE, VIDEO_BUFFER_SIZE, VIDEO_THREAD_STACK_SIZE, VID_3DS, WINDOW_HEIGHT,
+    WINDOW_WIDTH,
 };
+use constants::av::{CANNOT_CONFIGURE_3DS, CANNOT_FIND_3DS, MAX_QUEUED_FRAMES};
 use crossbeam::channel;
 use minifb::Scale;
 use minifb::ScaleMode;
@@ -339,10 +340,10 @@ impl FpsCounter {
 }
 
 fn main() {
-    let mut ds = get_3ds_device().expect("unable to locate 3ds device");
-    ds.configure().expect("could not configure 3ds");
+    let mut ds = get_3ds_device().expect(CANNOT_FIND_3DS);
+    ds.configure().expect(CANNOT_CONFIGURE_3DS);
 
-    // Start Audio
+    // Create audio output stream
     let (_audio_str, audio_stream_handle) =
         OutputStream::try_default().expect("couldnt create output stream");
     let sink = rodio::Sink::try_new(&audio_stream_handle).unwrap();
@@ -353,7 +354,7 @@ fn main() {
         minifb::Window::new("Krab3DS", WINDOW_WIDTH, WINDOW_HEIGHT, opts.inner()).unwrap();
     window.set_target_fps(TARGET_FPS);
 
-    // Start FPS
+    // Start FPS Counter
     let mut counter = FpsCounter::new();
 
     // Create channels for video and audio.
@@ -367,9 +368,9 @@ fn main() {
         channel::Receiver<[u8; AUDIO_BUFFER_SIZE]>,
     ) = channel::bounded(MAX_QUEUED_FRAMES);
 
-    // This needs to be optimized as it's currently quite large (both of them are)
+    // Spawn thread to fill buffers with video and audio data.
     std::thread::Builder::new()
-        .stack_size(200 * 1024 * 1024)
+        .stack_size(VIDEO_THREAD_STACK_SIZE)
         .spawn(move || loop {
             ds.write_control();
             ds.populate_buffers(&video_tx, &audio_tx);
@@ -378,15 +379,15 @@ fn main() {
         })
         .unwrap();
 
-    // Play with this stack size to see how large thread is
-    // We can probbaly trck to see so we can optimize
+    // Spawn thread to serve audio using the sink.
     std::thread::Builder::new()
-        .stack_size(40 * 1024 * 1024)
+        .stack_size(AUDIO_THREAD_STACK_SIZE)
         .spawn(move || loop {
             serve_audio(&sink, &audio_rx);
         })
         .unwrap();
 
+    // As long as window is open, serve video in main thread.
     while window.is_open() && !window.is_key_down(minifb::Key::Escape) {
         serve_video(&mut window, &video_rx);
     }


### PR DESCRIPTION
Closes #6 

This reduces stack sizes for the audio and video threads to 2MB and 10MB respectively.